### PR TITLE
add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.divyanshushekhar.flutter_process_text"
+
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
this for fix that issue 

* What went wrong: A problem occurred configuring project ':flutter_process_text'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /Users/niypoo/.pub-cache/hosted/pub.dev/flutter_process_text-1.1.2/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.